### PR TITLE
Handle test failures with no message

### DIFF
--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -48,7 +48,7 @@ class Failure < Struct.new(:element, :testcase, :testsuite)
   def message
     message = element.attributes['message'];
     if message.nil? || message.empty?
-      nil
+      element.attributes['type'].to_s
     else
       message.to_s
     end
@@ -71,10 +71,10 @@ junit_report_files = Dir.glob(File.join(junits_dir, "**", "*"))
 stats = { skipped: 0, failures: 0, tests: 0, assertions: 0, time: 0.0 }
 failures = []
 
+STDERR.puts "Parsing #{junit_report_files.length} junit file#{junit_report_files.length == 1 ? '' : 's'}"
 junit_report_files.sort.each do |file|
   next if File.directory?(file)
 
-  STDERR.puts "Parsing #{file.sub(junits_dir, '')}"
   xml = File.read(file)
   doc = REXML::Document.new(xml)
 

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -6,18 +6,12 @@ class AnnotateTest < Minitest::Test
     output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/minitest/")
 
     assert_equal <<~OUTPUT, output
-      Parsing TEST-AccountTest.xml
-      Parsing TEST-ClientForecastSyncingTest.xml
-      Parsing TEST-ClientTest.xml
-      Parsing TEST-CompanyTest.xml
-      Parsing TEST-UserBillableRatesTest.xml
-      Parsing TEST-UserCostRatesTest.xml
-      Parsing TEST-UserTest.xml
+      Parsing 8 junit files
       --- ❓ Checking failures
-      Ran 330 tests in 21.04s.
-      There are 3 failures/errors 😭
+      Ran 331 tests in 22.03s.
+      There are 4 failures/errors 😭
       --- ✍️ Preparing annotation
-      Ran **330** tests in **21.04s**.
+      Ran **331** tests in **22.03s**.
       <details>
       <summary><code>AccountTest#test_harvest_accounts_have_the_name_limited_to_90_characters</code></summary>
 
@@ -53,6 +47,18 @@ class AnnotateTest < Minitest::Test
       test/models/company_test.rb:2287:in `block (2 levels) in &lt;class:CompanyTest&gt;&#39;</code></pre>
 
       </details>
+
+      <details>
+      <summary><code>PayPalHelperTest#test_PayPal-availability-check_for_customers_in_india_doesn't_raise_if_company_has_been_deleted</code></summary>
+
+      <pre class=\"term\"><code>OpenSSL::Cipher::CipherError
+
+      app/models/asana_settings.rb:122:in `access_token&#39;
+      app/models/asana_settings.rb:100:in `revoke_token&#39;
+      app/models/company.rb:421:in `destroy&#39;
+      test/helpers/pay_pal_helper_test.rb:93:in `block in &lt;class:PayPalHelperTest&gt;&#39;</code></pre>
+
+      </details>
     OUTPUT
 
     assert_equal 0, status.exitstatus
@@ -62,7 +68,7 @@ class AnnotateTest < Minitest::Test
     output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/rspec/")
 
     assert_equal <<~OUTPUT, output
-      Parsing rspec.xml
+      Parsing 1 junit file
       --- ❓ Checking failures
       Ran 11 tests in 76.93s.
       There is 1 failure/error 😭

--- a/ruby/tests/minitest/TEST-PayPalHelperTest.xml
+++ b/ruby/tests/minitest/TEST-PayPalHelperTest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite time='0.993586' skipped='0' failures='0' errors='1' name="PayPalHelperTest" assertions='1' tests='1' timestamp="2024-04-10T19:38:51+00:00">
+  <testcase time='0.993586' file="test/helpers/pay_pal_helper_test.rb" name="test_PayPal-availability-check_for_customers_in_india_doesn&#39;t_raise_if_company_has_been_deleted" assertions='1'>
+    <error type='OpenSSL::Cipher::CipherError' message="">app/models/asana_settings.rb:122:in `access_token&#39;
+app/models/asana_settings.rb:100:in `revoke_token&#39;
+app/models/company.rb:421:in `destroy&#39;
+test/helpers/pay_pal_helper_test.rb:93:in `block in &lt;class:PayPalHelperTest&gt;&#39;
+    </error>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
/cc @harvesthq/ep and @pusewicz @maria-faulisi @braddunbar who encountered these

In [this build](https://buildkite.com/harvesthq/harvestapp/builds/41066) (and others) it seems like there's a new type of test failure that produce a junit file a bit different from what we've seen until now. The culprit is this error element that looks like:

```xml
<error type='OpenSSL::Cipher::CipherError' message="">
```

The code expected the `message` to always be present, it seems. I've made it fallback to use the `type` when there's no `message`. This repo is already a fork of the original plugin, because it didn't show things the way we liked (back in the day), I'm not planning to look much further than this :P